### PR TITLE
"Nines" bug fix

### DIFF
--- a/millify/__init__.py
+++ b/millify/__init__.py
@@ -1,16 +1,9 @@
-import math
 import re
-from decimal import Decimal
 
 __author__ = "Alexander Zaitsev (azaitsev@gmail.com)"
 __copyright__ = "Copyright 2018, azaitsev@gmail.com"
 __license__ = "MIT"
 __version__ = "0.1.1"
-
-
-def remove_exponent(d):
-    """Remove exponent."""
-    return d.quantize(Decimal(1)) if d == d.to_integral() else d.normalize()
 
 
 def millify(n, precision=0, drop_nulls=True, prefixes=[]):
@@ -20,12 +13,14 @@ def millify(n, precision=0, drop_nulls=True, prefixes=[]):
         millnames = ['']
         millnames.extend(prefixes)
     n = float(n)
-    millidx = max(0, min(len(millnames) - 1,
-                         int(math.floor(0 if n == 0 else math.log10(abs(n)) / 3))))
-    result = '{:.{precision}f}'.format(n / 10**(3 * millidx), precision=precision)
+    millidx = 0
+    while abs(n) >= 1000:
+        millidx += 1
+        n = round(n / 1000.0, precision)
+    result = '{}'.format(n)
     if drop_nulls:
-        result = remove_exponent(Decimal(result))
-    return '{0}{dx}'.format(result, dx=millnames[millidx])
+        result = result.rstrip('0').rstrip('.')
+    return '{}{dx}'.format(result, dx=millnames[millidx])
 
 
 def prettify(amount, separator=','):

--- a/millify/__init__.py
+++ b/millify/__init__.py
@@ -18,7 +18,7 @@ def millify(n, precision=0, drop_nulls=True, prefixes=[]):
         millidx += 1
         n = round(n / 1000.0, precision)
     if n < 1000:
-        round(n, precision) 
+        n = round(n, precision) 
     result = '{}'.format(n)
     if drop_nulls:
         result = result.rstrip('0').rstrip('.')

--- a/millify/__init__.py
+++ b/millify/__init__.py
@@ -17,6 +17,8 @@ def millify(n, precision=0, drop_nulls=True, prefixes=[]):
     while abs(n) >= 1000:
         millidx += 1
         n = round(n / 1000.0, precision)
+    if n < 1000:
+        round(n, precision) 
     result = '{}'.format(n)
     if drop_nulls:
         result = result.rstrip('0').rstrip('.')


### PR DESCRIPTION
# What bug does this PR fix?
- There's a bug where iterations of three 9s (`999`, `999999`, `999999999`, etc) should round up to the next `millname` (`999999` should become `1M`, but displays `1000k`).
- The cause was usage of the `math.floor()` when determining which prefix to append to inputted numbers. Floor rounds down to the nearest whole integer, forcing numbers that should be rounded up have one less `millidx` than they should at the time of string formatting. This has been replaced with python's native `round()` function, and has maintained the ability to use `precision` as an input parameter.
- `drop_nulls` logic has also been preserved in such a way that it happens during string formatting, thus the removal of `remove_exponents()` function which is unneeded with the current changes.
- `prettify()` logic remains untouched

# How was this PR tested?
- Ran series of `millify()` calls on numbers with known bugged outputs, and verified they now round up as intended.
- Ran series of `millify()` calls on non-bugged numbers to verify they still work as intended, toggling the various outputs and testing those as well
- NOTE: using a `precision=` value of 3 or higher still produces `1000.000k` instead of `1.000M`. However, it's in my personal opinion that, when using this module, users shouldn't need/want more than two decimal places showing in their string output anyway. If these changes are accepted, this note should probably go in the README / patch notes. Further, if anyone can figure out how to preserve the correct `millname` while using a precision value of 3 or higher, I haven't been able to yet but am open to all ideas!

## Related Ticket
- Closes #1 
- NOTE: not sure how versioning works for this project, but I've left `version = 0.1.1` as-is in this PR. Should these changes be accepted, you can determine if this needed versioned up to `0.1.2` or left alone! Thanks for reading, and kind regards!

## Screenshots
- before (with bug):
![Screen Shot 2021-06-17 at 1 49 20 PM](https://user-images.githubusercontent.com/19763395/122448517-d44d7700-cf72-11eb-913c-7344e09ecee5.png)
- after (bug fixed):
![Screen Shot 2021-06-17 at 1 51 17 PM](https://user-images.githubusercontent.com/19763395/122448754-1a0a3f80-cf73-11eb-9837-c48deabfa442.png)

