### PR TITLE
fix prettify custom separator

### DIFF
--- a/millify/__init__.py
+++ b/millify/__init__.py
@@ -35,4 +35,4 @@ def prettify(amount, separator=','):
     if orig == new:
         return new
     else:
-        return prettify(new)
+        return prettify(new, separator)


### PR DESCRIPTION
prettify was only using the custom separator once, then all latter separators defaulted to comma. reproducible with long numbers, e.g.
prettify(1000000000, "-")
-> '1,000,000-000'